### PR TITLE
Fix rc versions beeing reconized as release versions

### DIFF
--- a/pkg/src/stdver-api.ts
+++ b/pkg/src/stdver-api.ts
@@ -50,10 +50,10 @@ export default class StdVerAPI {
             throw new Error("invalid Standard Versioning identifier")
         let p: StdVerPhase
         switch (m[3]) {
-            case "a": p = StdVerPhase.alpha;      break
-            case "b": p = StdVerPhase.beta;       break
+            case "a": p = StdVerPhase.alpha;       break
+            case "b": p = StdVerPhase.beta;        break
             case "rc": p = StdVerPhase.candidate;  break
-            default:  p = StdVerPhase.release;    break
+            default:  p = StdVerPhase.release;     break
         }
         let S: StdVerScope | undefined
         if (m[7]) {

--- a/pkg/src/stdver-api.ts
+++ b/pkg/src/stdver-api.ts
@@ -52,7 +52,7 @@ export default class StdVerAPI {
         switch (m[3]) {
             case "a": p = StdVerPhase.alpha;      break
             case "b": p = StdVerPhase.beta;       break
-            case "c": p = StdVerPhase.candidate;  break
+            case "rc": p = StdVerPhase.candidate;  break
             default:  p = StdVerPhase.release;    break
         }
         let S: StdVerScope | undefined


### PR DESCRIPTION
The decoder identifies rc versions as release versions:

![grafik](https://github.com/user-attachments/assets/4e85a2bb-4297-4994-a55b-32e1e5a56bf7)

This is because the match is not hit and then the default case gets applied.